### PR TITLE
Don't fail when characters in REF allele have different case

### DIFF
--- a/src/com/rtg/vcf/VcfRecordMerger.java
+++ b/src/com/rtg/vcf/VcfRecordMerger.java
@@ -94,7 +94,7 @@ public class VcfRecordMerger implements AutoCloseable {
     for (final VcfRecord vcf : records) {
       if (pos != vcf.getStart() || length != vcf.getLength()) { // TODO: Handle gVCF merging
         throw new RuntimeException("Attempt to merge records with different reference span at: " + new SequenceNameLocusSimple(records[0]));
-      } else if (!refCall.equals(vcf.getRefCall())) {
+      } else if (!refCall.toLowerCase().equals(vcf.getRefCall().toLowerCase())) {
         throw new VcfFormatException("Records at " + new SequenceNameLocusSimple(records[0]) + " disagree on what the reference bases should be! (" + refCall + " != " + vcf.getRefCall() + ")");
       }
       final String[] ids = StringUtils.split(vcf.getId(), VcfUtils.VALUE_SEPARATOR);


### PR DESCRIPTION
I think this change is necessary to handle the case where either a variant caller drops reference lower-case masking, or where we compare a b37 result to a truthset which was created on hg19 (the only differences we expect may be in the repeat masking).

Another possibility would be to make this behavior optional?